### PR TITLE
Increase size value for Horizon widgets

### DIFF
--- a/src/Dashboard.java
+++ b/src/Dashboard.java
@@ -43,10 +43,10 @@ public class Dashboard implements Runnable {
 	private Context context;
     
 	//Static Values
-    private static final int DEF_WINDOW_WIDTH  	= 1200;
-    private static final int DEF_WINDOW_HEIGHT 	= 900;
-    private static final int ROUND_WIDGET_SIZE 	= 105;
-    private static final int DEFAULT_ZOOM_LEVEL = 4;
+    private static final int DEF_WINDOW_WIDTH  		= 1200;
+    private static final int DEF_WINDOW_HEIGHT 		= 900;
+    private static final int HORIZON_WIDGET_SIZE 	= 145;
+    private static final int DEFAULT_ZOOM_LEVEL 	= 4;
 
     //UI Widget Frame
     WidgetPanel widgetPanel;
@@ -252,9 +252,10 @@ public class Dashboard implements Runnable {
         outerPanel.add(AngleWidget.createDial(
                 context, Serial.HEADING, context.theme.roverTop));
         
-        if(context.getResource("widget_type", "Angles").equals("Horizon")){
+        //TODO - CP - Fix widget bug on the following two adds (horizon and radio widgets)
+        if(context.getResource("widget_type", "Angles").equals("Horizon")) {
             outerPanel.add(createHorizonWidget());
-            outerPanel.add(RadioWidget.create(context, ROUND_WIDGET_SIZE));
+            outerPanel.add(RadioWidget.create(context, HORIZON_WIDGET_SIZE));
         } 
         else {
         	outerPanel.add(
@@ -303,7 +304,7 @@ public class Dashboard implements Runnable {
         JPanel horizon =
             HorizonWidgets.makeHorizonWidget(
             		context,
-            		ROUND_WIDGET_SIZE, 
+            		HORIZON_WIDGET_SIZE, 
             		(ArtificialHorizon ah)->{registerHorizonListeners(ah, false);
             });
         

--- a/src/ui/ArtificialHorizon.java
+++ b/src/ui/ArtificialHorizon.java
@@ -23,28 +23,34 @@ import java.io.File;
 
 public class ArtificialHorizon extends JPanel {
     public interface RepaintCallback { void repaint(); }
+    
     /**
      * Ratio of display size to the distance between the inner bar of an
      *   axis indicator and the edge of the display
      */
     private static final float WDIST  = 3.0f/20.0f;
+    
     /**
      * Ratio of display size to the length of a full tick mark on an axis
      *   indicator
      */
     private static final float TICKH  = 1.0f/20.0f;
+    
     /**
      * Ratio of display size to the width of the indicator axis lines
      */
     private static final float STROKE = 1.0f/300.0f;
+    
     /**
      * Magnitude in abstract units between marks on the indicator axis
      */
     private static final float TICK_SCALE = 10f;
+    
     /**
      * Number of ticks to display on each indicator axis
      */
     private static final int TICK_COUNT = 20;
+    
     /**
      * Ratio of normal small indicator ticks to large labeled ticks
      */
@@ -55,6 +61,7 @@ public class ArtificialHorizon extends JPanel {
     private static final Color barColor = new Color(0xBBBBBB);
     private static final Color INDICATOR_COLOR = Color.GREEN;
     private static final Color CENTER_MARKER_COLOR = Color.YELLOW;
+    
     public enum DataAxis {
         TOP(new IndicatorBarSpecs(
             WDIST, WDIST, STROKE, 1f-2f*WDIST, Axis.X_AXIS, -TICKH,

--- a/src/ui/RadioWidget.java
+++ b/src/ui/RadioWidget.java
@@ -86,12 +86,12 @@ public class RadioWidget{
                 (int) (0.025*hUnit));
 
             // box sizes as ratios of height/width
-            int leftBoxX = (int) (0.05f*wUnit);
-            int rightBoxX = (int) (0.525f*wUnit);
-            int radioBoxY = (int) (0.50f*hUnit); // .35
-            int switchBoxY = (int) (0.25f*hUnit); // .2
-            int boxLength = (int) (0.425f*wUnit);
-            int switchBoxHeight = (int) (0.15f*hUnit);
+            int leftBoxX = 			(int) (0.05f * wUnit);
+            int rightBoxX = 		(int) (0.525f * wUnit);
+            int radioBoxY = 		(int) (0.50f * hUnit); // .35
+            int switchBoxY = 		(int) (0.25f * hUnit); // .2
+            int boxLength = 		(int) (0.425f * wUnit);
+            int switchBoxHeight = 	(int) (0.15f * hUnit);
 
             // Pick which switch box to fill
             boolean switchDown = data[4] <= 0.5;

--- a/src/ui/ninePatch/TransparentPanel.java
+++ b/src/ui/ninePatch/TransparentPanel.java
@@ -18,10 +18,14 @@ import javax.swing.border.*;
  */
 
 public class TransparentPanel extends JPanel {
-    private final int LEFT_MARGIN   = 8;
+
+	//Margin Consts
+	private final int LEFT_MARGIN   = 8;
     private final int RIGHT_MARGIN  = 8;
     private final int TOP_MARGIN    = 8;
     private final int BOTTOM_MARGIN = 8;
+    
+    //Vars
     private Rectangle drawRect;
     private NinePatch np;
     private int size;
@@ -29,13 +33,12 @@ public class TransparentPanel extends JPanel {
     public TransparentPanel(Context ctx, int size){
         this.size = size;
         np = ctx.theme.horizonBorder;
-        drawRect = new Rectangle(
-            LEFT_MARGIN,
-            TOP_MARGIN,
-            size-RIGHT_MARGIN-LEFT_MARGIN,
-            size-BOTTOM_MARGIN-TOP_MARGIN
-            );
-        setPreferredSize(new Dimension(size,size));
+        
+        drawRect = new Rectangle(LEFT_MARGIN, TOP_MARGIN,
+        		(size - RIGHT_MARGIN - LEFT_MARGIN), 
+        		(size - BOTTOM_MARGIN - TOP_MARGIN));
+        
+        setPreferredSize(new Dimension(size, size));
         setOpaque(false);
         setBorder(new EmptyBorder(TOP_MARGIN, LEFT_MARGIN, BOTTOM_MARGIN, RIGHT_MARGIN));
         setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));

--- a/src/ui/widgets/HorizonWidgets.java
+++ b/src/ui/widgets/HorizonWidgets.java
@@ -36,7 +36,7 @@ public class HorizonWidgets{
         sc.setup(horizon);
 
         container.add(horizon);
-        horizon.setPreferredSize(new Dimension(size,size));
+        horizon.setPreferredSize(new Dimension(size, size));
         return container;
     }
 


### PR DESCRIPTION
The layout manager isn't playing nice with the reduced size for horizon widgets. Proper resizing will occur on the vertical but not the horizontal. I've increased the preferred size value to match the current horizontal. this solves the image clipping, but the horizon widgets will be larger than other widgets for the time being.