### PR TITLE
Add user notification on initial low voltage telemetry reading

### DIFF
--- a/src/telemetry/TelemetryMonitor.java
+++ b/src/telemetry/TelemetryMonitor.java
@@ -158,7 +158,6 @@ public class TelemetryMonitor {
 		protected static final double BATTERY_LOW_WARNING_THRESHOLD = 6.5;
 		protected static final double BATTERY_LOW_CUTOFF_THRESHOLD 	= 6.0;
 		protected static final int 	  VCC_AVERAGING_SIZE 			= 20;
-		protected static final int 	  MAX_SEC_BELOW_THRESHOLD 		= 20;
 		protected static final int 	  LOW_VCC_SETTLING_TIME_MS 		= 20000;
 		protected static final int 	  VCC_EVAL_CYCLE_MS 			= 1000;
 		
@@ -182,8 +181,8 @@ public class TelemetryMonitor {
 		
 		/**
 		 * Adds a value to the sample array and increments the count.
-		 * Wraps to 0 once the end of the array is reached.
-		 * @param val
+		 * Wraps to index 0 once the end of the array is reached.
+		 * @param val - The sample value to be added
 		 */
 		public void add(double val) {
 			if(sampleIndex == VCC_AVERAGING_SIZE) {

--- a/src/ui/widgets/TelemetryDataWidget.java
+++ b/src/ui/widgets/TelemetryDataWidget.java
@@ -37,6 +37,7 @@ public class TelemetryDataWidget extends UIWidget {
 	protected TelemetryMonitor telemetryMonitor;
 	private int lineWidth;
 	private Collection<Line> lines = new ArrayList<Line>();
+
 	
 	/**
 	 * @author Chris Park @ Infinetix Corp.
@@ -93,6 +94,8 @@ public class TelemetryDataWidget extends UIWidget {
 	private class Line extends JLabel implements TelemetryListener, IMonitorListener {
         private String formatStr;
         private double currData;
+    	private boolean shouldNotifyUser;
+        
         
         /**
          * Class Constructor
@@ -106,6 +109,8 @@ public class TelemetryDataWidget extends UIWidget {
             
             telemetryMonitor.register(this);
             telemetryMonitor.start();
+            
+    		shouldNotifyUser = true;
         }
         
         /**
@@ -139,8 +144,20 @@ public class TelemetryDataWidget extends UIWidget {
         public void updateMonitor(TelemetryMonitor monitor) {
         	if(formatStr.contains("Vcc")) {
         		monitor.storeData(currData, TelemetryDataType.VOLTAGE);
+        		
+        		//If below the warning threshold, and this is
+        		//not a reset value (0.0), and we have not yet
+        		//warned the user, Do so now.
+        		if((currData < BATTERY_LOW_WARNING_THRESHOLD)
+				&& (currData > 0.0)
+				&& (shouldNotifyUser)) {
+        			JFrame messageFrame = new JFrame("message");
+        			JOptionPane.showMessageDialog(messageFrame,
+        					"Unit voltage is low and will soon shut down. " 
+        				  + "Replace or recharge batteries.");
+        			shouldNotifyUser = false;
+        		}
         	}
-        	
         }
         
         /**
@@ -151,6 +168,15 @@ public class TelemetryDataWidget extends UIWidget {
             super.repaint();
             TelemetryDataWidget.this.repaint(getX(), getY(), 
             		getWidth(), getHeight());
+        }
+        
+        /**
+         * Resets the boolean used to determine if this line should
+         * give a user facing notification when triggered to do so by
+         * some pre-defined, telemetry type specific event.
+         */
+        public void resetNotificationFlag() {
+        	shouldNotifyUser = true;
         }
 	}
 	
@@ -200,6 +226,7 @@ public class TelemetryDataWidget extends UIWidget {
 	public void reset() {
 		for(Line l : lines) {
 			l.update(0.0);
+			l.resetNotificationFlag();
 		}
 	}
 	


### PR DESCRIPTION
The low voltage warning is triggered on a VCC value below BATTERY_LOW_WARNING_THRESHOLD, but above 0.0 since this zero value is used on reset and initialization and would trigger a false positive notification.