### PR TITLE
Dashboard 1 5 update into debounce feature (#8)

### DIFF
--- a/resources/resources_en.properties
+++ b/resources/resources_en.properties
@@ -1,4 +1,4 @@
-version_id          =1.0.5
+version_id          =1.5.1
 release_date        =2021-10-27
 image_folder        =resources/images/
 patch_folder        =resources/images/nP/

--- a/src/serial/Messages/Message.java
+++ b/src/serial/Messages/Message.java
@@ -166,4 +166,8 @@ public class Message {
     public static Message disableBumper() {
     	return new WordMessage(Serial.COMMAND_WORD, Serial.DISABLE_BUMPER_CMD, (byte)0);
     }
+    
+    public static Message resetSettings() {
+    	return new WordMessage(Serial.COMMAND_WORD, Serial.SETTINGS_RESET_CMD, (byte)0);	
+    }
 }

--- a/src/serial/Serial.java
+++ b/src/serial/Serial.java
@@ -50,6 +50,7 @@ public class Serial {
     public static final byte START_CMD	  	 	= 0x6;
     public static final byte DISABLE_BUMPER_CMD	= 0x7;
     public static final byte ENABLE_BUMPER_CMD  = 0x8;
+    public static final byte SETTINGS_RESET_CMD = 0x9;
     
     //State types
     public static final byte APM_STATE	  	 = 0x0;

--- a/src/serial/SerialSender.java
+++ b/src/serial/SerialSender.java
@@ -191,9 +191,17 @@ public class SerialSender {
     	}
     }
     
+    /**
+     * Sends a message to the unit request that all telemetry settings be
+     * restored to their factory defaults.
+     */
+    public void resetSettings() {
+    	seriallog.warning("SerialSender - Requesting reset to default telemetry settings.");
+    	sendMessage(Message.resetSettings());
+    }
+    
     public void sendSync() {
         Message msg = Message.syncMessage(Serial.SYNC_REQUEST);
         sendMessage(msg);
     }
-    
 }

--- a/src/ui/telemetry/TelemetryDataWindow.java
+++ b/src/ui/telemetry/TelemetryDataWindow.java
@@ -30,6 +30,8 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseWheelListener;
 import java.awt.event.MouseEvent;
 
+import java.awt.event.ActionEvent;
+
 /**
  * @author Chris Park @ Infinetix Corp
  * Date: 3-3-21
@@ -66,9 +68,12 @@ public class TelemetryDataWindow implements ActionListener {
 	private JFrame FRM_Window;
 	private JPanel PNL_Main;
 	private JPanel PNL_Settings;
-	private JPanel PNL_Log;
+	private JPanel PNL_Top;
 	private JLabel LBL_Log;
 	private JTextField TXF_Log;
+	
+	private JButton BTN_RestoreDefaults;
+	
 	private JTextPane TXP_Description;
 	private JTextComponent TXC_DescriptionBox;
 	private JTable TBL_Telemetry;
@@ -191,22 +196,24 @@ public class TelemetryDataWindow implements ActionListener {
         PNL_Settings.add(SCL_SettingsSliders);
 
 		//Build Log Panel
-		PNL_Log = new JPanel();
-		PNL_Log.setLayout(new FlowLayout());
+		PNL_Top = new JPanel();
+		PNL_Top.setLayout(new FlowLayout());
 		LBL_Log = new JLabel("Set logging period (ms)");
 		TXF_Log = new JTextField();
 		TXF_Log.addActionListener(this);
 		TXF_Log.setText(Integer.toString(context.telemLog.getPeriod()));
 		TXF_Log.setColumns(LOG_FIELD_WIDTH);
-		PNL_Log.add(LBL_Log);
-		PNL_Log.add(TXF_Log);
+		BTN_RestoreDefaults = new JButton(restoreDefaultsAction);
+		PNL_Top.add(LBL_Log);
+		PNL_Top.add(TXF_Log);		
+		PNL_Top.add(BTN_RestoreDefaults);
 		
 		//Set up main JPanel
 		PNL_Main = new JPanel();
 		PNL_Main.setLayout(new BoxLayout(PNL_Main, BoxLayout.PAGE_AXIS));
 		
 		//Add everything to main JPanel
-		PNL_Main.add(PNL_Log);
+		PNL_Main.add(PNL_Top);
 		PNL_Main.add(SCL_Telemetry);
 		PNL_Main.add(PNL_Settings);
 		PNL_Main.add(TXP_Description);
@@ -353,4 +360,18 @@ public class TelemetryDataWindow implements ActionListener {
 			TBL_SettingsSliders.getModel().setValueAt(percentage, i, 0);
 		}
 	}
+	
+	/**
+	 * Action used to restore telemetry values to their default settings.
+	 */
+	private Action restoreDefaultsAction = new AbstractAction() {
+		{
+			String text = "Restore Defaults";
+			putValue(Action.NAME, text);
+		}
+		
+		public void actionPerformed(ActionEvent e) {
+			context.sender.resetSettings();
+		}
+	};
 }


### PR DESCRIPTION
* Version bump

* Update groundSettings.xml

* Update resources_en.properties

* Revert "Gps precision update (#1)"

This reverts commit 45a48c0923932c12d74751bde33ccdc067f02a74.

* Delete groundSettings.xml

* Pull in removal of groundSettings.xml and updated slider range calculation (#4)

* Gps precision squash

* Add precision GPS types to telemetry IDs

* Update telemetry parsing to support mixed types

Telemetry parsing now supports mixed type precision for lat/long gps values

* rework bit shifting to be correct

* Update SerialParser.java

* adjust getTelemetry call to handle double instead of float

* Increased the allowed range for settings to 72

* Convert telemetry float values to doubles across the code base

convert telemetry focused float variables and structures to double variables and structures. This probably breaks the graph and the waypoint panel in some way... Testing will bear it out.

* Reworked precision telemetry value parsing logic

...

* Update SerialParser.java

updates for ground settings

Update groundSettings.xml

Update groundSettings.xml

* Revert "Gps precision squash"

This reverts commit 7b997f946494e288931c7e6f4dd0d6439f9e90cf.

* Take abs value of slider range for settings

* Delete groundSettings.xml

Should not be tracked in the repository.

* Update .gitignore

* Update .gitignore

* Add GPS and heading lock labels back into props

* Feature telemetry settings reset to default (#7)

* Add Restore to defaults button

-Added UI Button
-Added on click Action Event function stub for restore logic (To be implemented)

* add a todo for upcoming task switch

* Add reset to defaults command

Add Command message and tie it to the defaults button in the data window

* Dashboard 1 0 5 (#5)

* Update groundSettings.xml

* Update resources_en.properties

* Revert "Gps precision update (#1)"

This reverts commit 45a48c0923932c12d74751bde33ccdc067f02a74.

* Delete groundSettings.xml

* Pull in removal of groundSettings.xml and updated slider range calculation (#4)

* Gps precision squash

* Add precision GPS types to telemetry IDs

* Update telemetry parsing to support mixed types

Telemetry parsing now supports mixed type precision for lat/long gps values

* rework bit shifting to be correct

* Update SerialParser.java

* adjust getTelemetry call to handle double instead of float

* Increased the allowed range for settings to 72

* Convert telemetry float values to doubles across the code base

convert telemetry focused float variables and structures to double variables and structures. This probably breaks the graph and the waypoint panel in some way... Testing will bear it out.

* Reworked precision telemetry value parsing logic

...

* Update SerialParser.java

updates for ground settings

Update groundSettings.xml

Update groundSettings.xml

* Revert "Gps precision squash"

This reverts commit 7b997f946494e288931c7e6f4dd0d6439f9e90cf.

* Take abs value of slider range for settings

* Delete groundSettings.xml

Should not be tracked in the repository.

* Update .gitignore

* Update .gitignore

* Add GPS and heading lock labels back into props

* Add event log for default settings reset

* Change dashboard version format