### PR TITLE
Add fence draw corrections

### DIFF
--- a/src/map/geofence/GeofenceType.java
+++ b/src/map/geofence/GeofenceType.java
@@ -37,5 +37,6 @@ public abstract class GeofenceType {
 	public abstract void setOriginLatLng(double lat, double lng);
 	public abstract void updateRadiusFeet(double new_radius_ft);
 	protected abstract void setRadiusLng();
+	protected abstract double applyDrawOffset(double fenceDiameter);
 	
 }

--- a/src/map/geofence/GeofenceTypeCircle.java
+++ b/src/map/geofence/GeofenceTypeCircle.java
@@ -17,7 +17,15 @@ import java.awt.BasicStroke;
  * drawing behavior for a circular fence.
  */
 public class GeofenceTypeCircle extends GeofenceType {
+	
+	//Geofence zone offset multipliers
+	//Zone 1 - No multiplier
+	private static final double ZONE_2_MULTIPLIER = 0.1;
+	private static final double ZONE_3_MULTIPLIER = 0.2;
+	
+	//Geofence line width
 	protected BasicStroke lineStroke;
+	
 	/**
 	 * Constructor
 	 * @param radius_ft - the radius to the edge of the fence from the origin
@@ -54,6 +62,11 @@ public class GeofenceTypeCircle extends GeofenceType {
 		double a = Math.pow((2 * length), 2);;
 		double b = Math.pow((2 * length), 2);;
 		double fenceDiameter = Math.sqrt(a + b);
+		
+		//Apply a corrective multiplier to the drawn fence diameter
+		//to account for map distortions created by longitudinal 
+		//variations on a mercator map
+		fenceDiameter = applyDrawOffset(fenceDiameter);
 		
 		//Draw the fence. The drawOval function assumes drawing starts
 		//from a top left corner point much like a square would be drawn,
@@ -122,5 +135,33 @@ public class GeofenceTypeCircle extends GeofenceType {
 		
 		radiusPoint = new Dot(origin.getLatitude(), 
 				origin.getLongitude() + degreesLng, origin.getAltitude());
+	}
+	
+	/**
+	 * Applies a multiplier to the current geofence size to correct
+	 * for drawing size error created by converting Lat/Lng (Spherical)
+	 * coordinate values to 2D (Cartesian) space. This helps the fence
+	 * as drawn to better line up with the real spherical coordinate
+	 * range. The multiplier is determined by pre-defined zones calculated 
+	 * along ranges in latitude.
+	 * @param fenceDiameter - The diameter of the fence to be corrected
+	 * @return - double - the new fence diameter
+	 */
+	protected double applyDrawOffset(double fenceDiameter) {
+		
+		double latPos = origin.getLatitude();
+		
+		  //Zone 1
+		if(latPos >= 41.0) {
+			System.err.println("Zone 1");
+			return fenceDiameter;
+		} //Zone 2
+		else if ((latPos < 41.0) && (latPos >= 34.0)) {
+			System.err.println("Zone 2");
+			return (fenceDiameter - (fenceDiameter * ZONE_2_MULTIPLIER));
+		}
+		  //Zone 3
+		System.err.println("Zone 3");
+		return (fenceDiameter - (fenceDiameter * ZONE_3_MULTIPLIER));
 	}
 }

--- a/src/map/geofence/GeofenceTypeSquare.java
+++ b/src/map/geofence/GeofenceTypeSquare.java
@@ -114,4 +114,19 @@ public class GeofenceTypeSquare extends GeofenceType {
 		radiusPoint = new Dot(origin.getLatitude(), 
 				origin.getLongitude() + degreesLng, origin.getAltitude());
 	}
+	
+	/**
+	 * Applies a multiplier to the current geofence size to correct
+	 * for drawing size error created by converting Lat/Lng (Spherical)
+	 * coordinate values to 2D (Cartesian) space. This helps the fence
+	 * as drawn to better line up with the real spherical coordinate
+	 * range. The multiplier is determined by pre-defined zones calculated 
+	 * along ranges in latitude.
+	 * @param fenceDiameter - The diameter of the fence to be corrected
+	 * @return - double - the new fence diameter
+	 */
+	protected double applyDrawOffset(double fenceDiameter) {
+		//To Be Implemented
+		return 0.0;
+	}
 }


### PR DESCRIPTION
Added a function to re-calculate the drawn fence diameter based upon pre defined latitude zone ranges. This helps to correct improper fence sizing due to longitudinal distortions that are a side effect of Mercator map projections.